### PR TITLE
Fix the vulnerability found in package vite and release a version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.7] - 2025-10-27
+
+### fixed CVE-2025-62522 vulnerability found in package vite in project
+
+- In project test-app [JIRA](https://scheduleonce.atlassian.net/browse/ONCEHUB-105431)
+
 ## [2.0.5] - 2024-02-27
 
 ### fixed vulnerability in package @angular/core

--- a/builder/package-lock.json
+++ b/builder/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oncehub/ng-strictify",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oncehub/ng-strictify",
-      "version": "2.0.6",
+      "version": "2.0.7",
       "license": "MIT",
       "dependencies": {
         "@angular-devkit/architect": "^0.2003.4"

--- a/builder/package.json
+++ b/builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oncehub/ng-strictify",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "Incrementally update your Angular project to use the Typescript strict flag.",
   "main": "dist/src/index.js",
   "builders": "builders.json",

--- a/test-app/package-lock.json
+++ b/test-app/package-lock.json
@@ -326,14 +326,14 @@
       }
     },
     "node_modules/@angular/build": {
-      "version": "20.3.4",
-      "resolved": "https://registry.npmjs.org/@angular/build/-/build-20.3.4.tgz",
-      "integrity": "sha512-2ZPyEQxg9FCM7gv5NZHZVCec6ubb7HM/fkzr7wcYQArN8E8EknlyfXn6G5AoqkEsQZGqtJOD8sfti0m4kYiwkQ==",
+      "version": "20.3.7",
+      "resolved": "https://registry.npmjs.org/@angular/build/-/build-20.3.7.tgz",
+      "integrity": "sha512-NHN5JNDqUc0Ux4IZPCe/fpFAnuRHujkxVfRHSqDFW5+jtj2JuW1XO6qlX+kDheFRlj/NvFgTpidKsE9IjpfMWQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "2.3.0",
-        "@angular-devkit/architect": "0.2003.4",
+        "@angular-devkit/architect": "0.2003.7",
         "@babel/core": "7.28.3",
         "@babel/helper-annotate-as-pure": "7.27.3",
         "@babel/helper-split-export-declaration": "7.24.7",
@@ -356,7 +356,7 @@
         "semver": "7.7.2",
         "source-map-support": "0.5.21",
         "tinyglobby": "0.2.14",
-        "vite": "7.1.5",
+        "vite": "7.1.11",
         "watchpack": "2.4.4"
       },
       "engines": {
@@ -375,7 +375,7 @@
         "@angular/platform-browser": "^20.0.0",
         "@angular/platform-server": "^20.0.0",
         "@angular/service-worker": "^20.0.0",
-        "@angular/ssr": "^20.3.4",
+        "@angular/ssr": "^20.3.7",
         "karma": "^6.4.0",
         "less": "^4.2.0",
         "ng-packagr": "^20.0.0",
@@ -420,6 +420,50 @@
           "optional": true
         },
         "vitest": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@angular/build/node_modules/@angular-devkit/architect": {
+      "version": "0.2003.7",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.2003.7.tgz",
+      "integrity": "sha512-NGHLfrNQNjwWwvyQomMM1AqRaqH3UU0TwySJh9XlSc9dC/roB5zD2NjLf98K4LfAIfHvDBwkQ+dMo3F556/Xuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@angular-devkit/core": "20.3.7",
+        "rxjs": "7.8.2"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
+        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
+        "yarn": ">= 1.13.0"
+      }
+    },
+    "node_modules/@angular/build/node_modules/@angular-devkit/core": {
+      "version": "20.3.7",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-20.3.7.tgz",
+      "integrity": "sha512-psmcjwYcXve4sLrcdnARc15/Wfd3RpydbtLo9+mViNzk5HQ6L2eEztKl/2QVYMgzZVIa1GfhjwUllVCyLAv3sg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "8.17.1",
+        "ajv-formats": "3.0.1",
+        "jsonc-parser": "3.3.1",
+        "picomatch": "4.0.3",
+        "rxjs": "7.8.2",
+        "source-map": "0.7.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
+        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
+        "yarn": ">= 1.13.0"
+      },
+      "peerDependencies": {
+        "chokidar": "^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "chokidar": {
           "optional": true
         }
       }
@@ -8906,9 +8950,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.5.tgz",
-      "integrity": "sha512-4cKBO9wR75r0BeIWWWId9XK9Lj6La5X846Zw9dFfzMRw38IlTk2iCcUt6hsyiDRcPidc55ZParFYDXi0nXOeLQ==",
+      "version": "7.1.11",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.11.tgz",
+      "integrity": "sha512-uzcxnSDVjAopEUjljkWh8EIrg6tlzrjFUfMcR1EVsRDGwf/ccef0qQPRyOrROwhrTDaApueq+ja+KLPlzR/zdg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9569,13 +9613,13 @@
       }
     },
     "@angular/build": {
-      "version": "20.3.4",
-      "resolved": "https://registry.npmjs.org/@angular/build/-/build-20.3.4.tgz",
-      "integrity": "sha512-2ZPyEQxg9FCM7gv5NZHZVCec6ubb7HM/fkzr7wcYQArN8E8EknlyfXn6G5AoqkEsQZGqtJOD8sfti0m4kYiwkQ==",
+      "version": "20.3.7",
+      "resolved": "https://registry.npmjs.org/@angular/build/-/build-20.3.7.tgz",
+      "integrity": "sha512-NHN5JNDqUc0Ux4IZPCe/fpFAnuRHujkxVfRHSqDFW5+jtj2JuW1XO6qlX+kDheFRlj/NvFgTpidKsE9IjpfMWQ==",
       "dev": true,
       "requires": {
         "@ampproject/remapping": "2.3.0",
-        "@angular-devkit/architect": "0.2003.4",
+        "@angular-devkit/architect": "0.2003.7",
         "@babel/core": "7.28.3",
         "@babel/helper-annotate-as-pure": "7.27.3",
         "@babel/helper-split-export-declaration": "7.24.7",
@@ -9599,10 +9643,34 @@
         "semver": "7.7.2",
         "source-map-support": "0.5.21",
         "tinyglobby": "0.2.14",
-        "vite": "7.1.5",
+        "vite": "7.1.11",
         "watchpack": "2.4.4"
       },
       "dependencies": {
+        "@angular-devkit/architect": {
+          "version": "0.2003.7",
+          "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.2003.7.tgz",
+          "integrity": "sha512-NGHLfrNQNjwWwvyQomMM1AqRaqH3UU0TwySJh9XlSc9dC/roB5zD2NjLf98K4LfAIfHvDBwkQ+dMo3F556/Xuw==",
+          "dev": true,
+          "requires": {
+            "@angular-devkit/core": "20.3.7",
+            "rxjs": "7.8.2"
+          }
+        },
+        "@angular-devkit/core": {
+          "version": "20.3.7",
+          "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-20.3.7.tgz",
+          "integrity": "sha512-psmcjwYcXve4sLrcdnARc15/Wfd3RpydbtLo9+mViNzk5HQ6L2eEztKl/2QVYMgzZVIa1GfhjwUllVCyLAv3sg==",
+          "dev": true,
+          "requires": {
+            "ajv": "8.17.1",
+            "ajv-formats": "3.0.1",
+            "jsonc-parser": "3.3.1",
+            "picomatch": "4.0.3",
+            "rxjs": "7.8.2",
+            "source-map": "0.7.6"
+          }
+        },
         "picomatch": {
           "version": "4.0.3",
           "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
@@ -14852,9 +14920,9 @@
       "dev": true
     },
     "vite": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.5.tgz",
-      "integrity": "sha512-4cKBO9wR75r0BeIWWWId9XK9Lj6La5X846Zw9dFfzMRw38IlTk2iCcUt6hsyiDRcPidc55ZParFYDXi0nXOeLQ==",
+      "version": "7.1.11",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.11.tgz",
+      "integrity": "sha512-uzcxnSDVjAopEUjljkWh8EIrg6tlzrjFUfMcR1EVsRDGwf/ccef0qQPRyOrROwhrTDaApueq+ja+KLPlzR/zdg==",
       "dev": true,
       "requires": {
         "esbuild": "^0.25.0",


### PR DESCRIPTION
This pull request updates the project to version 2.0.7 and addresses a security vulnerability in the `vite` package. It also includes dependency updates for Angular-related packages in the `test-app` and synchronizes version numbers across relevant files.

**Security and Dependency Updates:**

* Upgraded the `vite` package from `7.1.5` to `7.1.11` in `test-app/package-lock.json` to fix CVE-2025-62522. [[1]](diffhunk://#diff-d882a6da5405468b3c5566a97ab3d19fb1d7e6c4d088fb0f027b4f2244cd4767L359-R359) [[2]](diffhunk://#diff-d882a6da5405468b3c5566a97ab3d19fb1d7e6c4d088fb0f027b4f2244cd4767L8909-R8955) [[3]](diffhunk://#diff-d882a6da5405468b3c5566a97ab3d19fb1d7e6c4d088fb0f027b4f2244cd4767L14855-R14925)
* Updated Angular packages (`@angular/build`, `@angular-devkit/architect`, `@angular-devkit/core`, `@angular/ssr`) to version `20.3.7` in `test-app/package-lock.json` for improved compatibility and security. [[1]](diffhunk://#diff-d882a6da5405468b3c5566a97ab3d19fb1d7e6c4d088fb0f027b4f2244cd4767L329-R336) [[2]](diffhunk://#diff-d882a6da5405468b3c5566a97ab3d19fb1d7e6c4d088fb0f027b4f2244cd4767L378-R378) [[3]](diffhunk://#diff-d882a6da5405468b3c5566a97ab3d19fb1d7e6c4d088fb0f027b4f2244cd4767R427-R470) [[4]](diffhunk://#diff-d882a6da5405468b3c5566a97ab3d19fb1d7e6c4d088fb0f027b4f2244cd4767L9572-R9622) [[5]](diffhunk://#diff-d882a6da5405468b3c5566a97ab3d19fb1d7e6c4d088fb0f027b4f2244cd4767L9602-R9673)

**Version Management:**

* Bumped project version to `2.0.7` in `builder/package.json` and `builder/package-lock.json` to reflect the new release. [[1]](diffhunk://#diff-621fcb45dffbf8ffaa19489a37735540b46386048cec56d58e8cfb08e2735748L3-R3) [[2]](diffhunk://#diff-f2fc4931f1975302404427ab0f6cb36bbf49db6e6a5740d91829183adc8ad8cfL3-R9)
* Added a changelog entry for version `2.0.7`, documenting the fix for the `vite` vulnerability (CVE-2025-62522) and referencing the related JIRA ticket.