### PR TITLE
CVE-GHSA-29xp-372q-xqph vulnerability found in package tar in project ng-strictify

### DIFF
--- a/builder/package-lock.json
+++ b/builder/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oncehub/ng-strictify",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oncehub/ng-strictify",
-      "version": "2.0.7",
+      "version": "2.0.8",
       "license": "MIT",
       "dependencies": {
         "@angular-devkit/architect": "^0.2003.4"

--- a/builder/package.json
+++ b/builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oncehub/ng-strictify",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "Incrementally update your Angular project to use the Typescript strict flag.",
   "main": "dist/src/index.js",
   "builders": "builders.json",

--- a/test-app/package-lock.json
+++ b/test-app/package-lock.json
@@ -4387,11 +4387,11 @@
       "license": "ISC"
     },
     "node_modules/cacache/node_modules/tar": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.1.tgz",
-      "integrity": "sha512-nlGpxf+hv0v7GkWBK2V9spgactGOp0qvfWRxUMjqHyzrt3SgwE48DIv/FhqPHJYLHpgW1opq3nERbz5Anq7n1g==",
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.2.tgz",
+      "integrity": "sha512-7NyxrTE4Anh8km8iEy7o0QYPs+0JKBTj5ZaqHg6B39erLg0qYXN3BijtShwbsNSvQ+LN75+KV+C4QR/f6Gwnpg==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
         "chownr": "^3.0.0",
@@ -7036,11 +7036,11 @@
       }
     },
     "node_modules/node-gyp/node_modules/tar": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.1.tgz",
-      "integrity": "sha512-nlGpxf+hv0v7GkWBK2V9spgactGOp0qvfWRxUMjqHyzrt3SgwE48DIv/FhqPHJYLHpgW1opq3nERbz5Anq7n1g==",
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.2.tgz",
+      "integrity": "sha512-7NyxrTE4Anh8km8iEy7o0QYPs+0JKBTj5ZaqHg6B39erLg0qYXN3BijtShwbsNSvQ+LN75+KV+C4QR/f6Gwnpg==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
         "chownr": "^3.0.0",
@@ -11876,9 +11876,9 @@
           "dev": true
         },
         "tar": {
-          "version": "7.5.1",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.1.tgz",
-          "integrity": "sha512-nlGpxf+hv0v7GkWBK2V9spgactGOp0qvfWRxUMjqHyzrt3SgwE48DIv/FhqPHJYLHpgW1opq3nERbz5Anq7n1g==",
+          "version": "7.5.2",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.2.tgz",
+          "integrity": "sha512-7NyxrTE4Anh8km8iEy7o0QYPs+0JKBTj5ZaqHg6B39erLg0qYXN3BijtShwbsNSvQ+LN75+KV+C4QR/f6Gwnpg==",
           "dev": true,
           "requires": {
             "@isaacs/fs-minipass": "^4.0.0",
@@ -13642,9 +13642,9 @@
           "dev": true
         },
         "tar": {
-          "version": "7.5.1",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.1.tgz",
-          "integrity": "sha512-nlGpxf+hv0v7GkWBK2V9spgactGOp0qvfWRxUMjqHyzrt3SgwE48DIv/FhqPHJYLHpgW1opq3nERbz5Anq7n1g==",
+          "version": "7.5.2",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.2.tgz",
+          "integrity": "sha512-7NyxrTE4Anh8km8iEy7o0QYPs+0JKBTj5ZaqHg6B39erLg0qYXN3BijtShwbsNSvQ+LN75+KV+C4QR/f6Gwnpg==",
           "dev": true,
           "requires": {
             "@isaacs/fs-minipass": "^4.0.0",


### PR DESCRIPTION
This pull request includes a version bump for the `@oncehub/ng-strictify` package and updates to the `tar` dependency in the test application. The main changes are focused on keeping dependencies up to date and ensuring accurate versioning information for package management.

Dependency and version updates:

* Bumped the version of `@oncehub/ng-strictify` from `2.0.7` to `2.0.8` in both `package.json` and `package-lock.json` to reflect the latest release. [[1]](diffhunk://#diff-621fcb45dffbf8ffaa19489a37735540b46386048cec56d58e8cfb08e2735748L3-R3) [[2]](diffhunk://#diff-f2fc4931f1975302404427ab0f6cb36bbf49db6e6a5740d91829183adc8ad8cfL3-R9)

Test application dependency updates:

* Updated the `tar` dependency from version `7.5.1` to `7.5.2` in multiple locations within `test-app/package-lock.json`, including a license change from `ISC` to `BlueOak-1.0.0`. [[1]](diffhunk://#diff-d882a6da5405468b3c5566a97ab3d19fb1d7e6c4d088fb0f027b4f2244cd4767L4390-R4394) [[2]](diffhunk://#diff-d882a6da5405468b3c5566a97ab3d19fb1d7e6c4d088fb0f027b4f2244cd4767L7039-R7043) [[3]](diffhunk://#diff-d882a6da5405468b3c5566a97ab3d19fb1d7e6c4d088fb0f027b4f2244cd4767L11879-R11881) [[4]](diffhunk://#diff-d882a6da5405468b3c5566a97ab3d19fb1d7e6c4d088fb0f027b4f2244cd4767L13645-R13647)