### PR TITLE
Updated node version in workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -13,7 +13,7 @@ jobs:
       # setup .npmrc file to publish to npm
       - uses: actions/setup-node@v3
         with:
-          node-version: "20.x"
+          node-version: "24.11.0"
           registry-url: "https://registry.npmjs.org"
       - name: "Publish"
         working-directory: ./builder


### PR DESCRIPTION
This pull request makes a minor update to the Node.js version used in the npm publish workflow, ensuring compatibility with the latest features and security updates. 

* Updated the Node.js version in `.github/workflows/npm-publish.yml` from `20.x` to `24.11.0` for the npm publish workflow.