### PR TITLE
chore: bump version to 2.0.10-beta.4 in package.json and package-lock json

### DIFF
--- a/builder/package-lock.json
+++ b/builder/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oncehub/ng-strictify",
-  "version": "2.0.10-beta.3",
+  "version": "2.0.10-beta.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oncehub/ng-strictify",
-      "version": "2.0.10-beta.3",
+      "version": "2.0.10-beta.4",
       "license": "MIT",
       "dependencies": {
         "@angular-devkit/architect": "^0.2102.3"

--- a/builder/package.json
+++ b/builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oncehub/ng-strictify",
-  "version": "2.0.10-beta.3",
+  "version": "2.0.10-beta.4",
   "description": "Incrementally update your Angular project to use the Typescript strict flag.",
   "main": "dist/src/index.js",
   "builders": "builders.json",


### PR DESCRIPTION
This pull request updates the package version for `@oncehub/ng-strictify` from `2.0.10-beta.3` to `2.0.10-beta.4` in both the `package.json` and `package-lock.json` files. No other changes are included. 

- Bumped the package version to `2.0.10-beta.4` in `package.json`
- Updated the version to `2.0.10-beta.4` in `package-lock.json`