### PR TITLE
Pythons/oncehub 122927

### DIFF
--- a/test-app/package-lock.json
+++ b/test-app/package-lock.json
@@ -7233,9 +7233,9 @@
       }
     },
     "node_modules/piscina": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/piscina/-/piscina-5.1.4.tgz",
-      "integrity": "sha512-7uU4ZnKeQq22t9AsmHGD2w4OYQGonwFnTypDypaWi7Qr2EvQIFVtG8J5D/3bE7W123Wdc9+v4CZDu5hJXVCtBg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/piscina/-/piscina-5.2.0.tgz",
+      "integrity": "sha512-DszUCKeVN/5G5QKo6jAVHL8fmKnkJvQ0ACiVgY7YGCq3TUB2oznAOayvZPIAdEThvhczkXR+qm3IHsNXpFCYfA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/test-app/package-lock.json
+++ b/test-app/package-lock.json
@@ -15,8 +15,8 @@
         "@angular/platform-browser-dynamic": "21.2.17"
       },
       "devDependencies": {
-        "@angular/build": "21.2.15",
-        "@angular/cli": "21.2.15",
+        "@angular/build": "21.2.16",
+        "@angular/cli": "21.2.16",
         "@angular/compiler-cli": "21.2.17",
         "@oncehub/ng-strictify": "2.0.10",
         "@types/node": "^25.5.0",
@@ -250,13 +250,13 @@
       }
     },
     "node_modules/@angular-devkit/architect": {
-      "version": "0.2102.15",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.2102.15.tgz",
-      "integrity": "sha512-EZQXu6j7J7OUxmpxIO2mxd58NTlCb7HOAOfLLGdk7lRcwZeCxnjGRzb72tXlJgIEi3IoOYwcW0ft2cg7r/d6qA==",
+      "version": "0.2102.16",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.2102.16.tgz",
+      "integrity": "sha512-FDUKPpq70nJwGK4CICPD31XmesBEGv57Z+JBCPWrTa5mVZIXCQkeo5waIaNfzAnLdbpd74ULJJ3MDNVt4iaGZg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "21.2.15",
+        "@angular-devkit/core": "21.2.16",
         "rxjs": "7.8.2"
       },
       "bin": {
@@ -269,9 +269,9 @@
       }
     },
     "node_modules/@angular-devkit/core": {
-      "version": "21.2.15",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-21.2.15.tgz",
-      "integrity": "sha512-x7EwuQtMGHANVznHpwyEi/3lMo/kRoaxV2w7lXbRGjTezwv4SPaOBwhrIGCbAVFs5B1ziff4jZzors4owlCTgg==",
+      "version": "21.2.16",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-21.2.16.tgz",
+      "integrity": "sha512-bRot0dqonxdSuGzXyOYtVJis/u9CJycrfC/aaxLeMF37gKtWIyCR2KFkMRXAoiV/AKk5/NuuqDNqcQS9w5G3Fg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -297,13 +297,13 @@
       }
     },
     "node_modules/@angular-devkit/schematics": {
-      "version": "21.2.15",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-21.2.15.tgz",
-      "integrity": "sha512-kHHV694KUPuXlItjvnxUspn+KYjlTKu8KINX/kT1qlogzLYojpnRwcUtZyRPUz1f/M1d3TUHVFeBKx+h5HoNcA==",
+      "version": "21.2.16",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-21.2.16.tgz",
+      "integrity": "sha512-3wTn2N6iWxYLrRaFDk3J3a6P3OxL+yvYGoDA7pNKfI+Nu0PpTK8BBwhNQD8L5P3US/QGWTkMNbzZ7XxBBfFP/g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "21.2.15",
+        "@angular-devkit/core": "21.2.16",
         "jsonc-parser": "3.3.1",
         "magic-string": "0.30.21",
         "ora": "9.3.0",
@@ -316,14 +316,14 @@
       }
     },
     "node_modules/@angular/build": {
-      "version": "21.2.15",
-      "resolved": "https://registry.npmjs.org/@angular/build/-/build-21.2.15.tgz",
-      "integrity": "sha512-APJ5v0/hL38CKSqSQDos5Y8/O2LSiSSqP9FagdcMT5j9JAlENXdhVaA3IxPMXDWcxtzD5T1IlN8Z9aFxDXxHyg==",
+      "version": "21.2.16",
+      "resolved": "https://registry.npmjs.org/@angular/build/-/build-21.2.16.tgz",
+      "integrity": "sha512-40Ra2lM/KDPwA68wP6ZX7zVQak/ouo1sTmtUmjUpqihDp5ftXAZWD3t2Mm4Ja88cyHzG3kaI3C0ew/wAdcEeDA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "2.3.0",
-        "@angular-devkit/architect": "0.2102.15",
+        "@angular-devkit/architect": "0.2102.16",
         "@babel/core": "7.29.0",
         "@babel/helper-annotate-as-pure": "7.27.3",
         "@babel/helper-split-export-declaration": "7.24.7",
@@ -366,7 +366,7 @@
         "@angular/platform-browser": "^21.0.0",
         "@angular/platform-server": "^21.0.0",
         "@angular/service-worker": "^21.0.0",
-        "@angular/ssr": "^21.2.15",
+        "@angular/ssr": "^21.2.16",
         "karma": "^6.4.0",
         "less": "^4.2.0",
         "ng-packagr": "^21.0.0",
@@ -416,26 +416,26 @@
       }
     },
     "node_modules/@angular/cli": {
-      "version": "21.2.15",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-21.2.15.tgz",
-      "integrity": "sha512-8CT1iST5CwdxHEzC0NVFUsMenAY7aE30ayTAw5PpA6MPs6bdHlL6QxTmkqThW7hoCj6PJ56YfQMzSQU+aYRLQA==",
+      "version": "21.2.16",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-21.2.16.tgz",
+      "integrity": "sha512-/O2Bsy4jae/op06ejyfsL6K4cD4yo7TEH9iesD4UPEvcWTnV8lCdmE2oxbc1WGT3DIsZ00yBQhURSbetDPGFCg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/architect": "0.2102.15",
-        "@angular-devkit/core": "21.2.15",
-        "@angular-devkit/schematics": "21.2.15",
+        "@angular-devkit/architect": "0.2102.16",
+        "@angular-devkit/core": "21.2.16",
+        "@angular-devkit/schematics": "21.2.16",
         "@inquirer/prompts": "7.10.1",
         "@listr2/prompt-adapter-inquirer": "3.0.5",
         "@modelcontextprotocol/sdk": "1.26.0",
-        "@schematics/angular": "21.2.15",
+        "@schematics/angular": "21.2.16",
         "@yarnpkg/lockfile": "1.1.0",
         "algoliasearch": "5.48.1",
         "ini": "6.0.0",
         "jsonc-parser": "3.3.1",
         "listr2": "9.0.5",
         "npm-package-arg": "13.0.2",
-        "pacote": "21.3.1",
+        "pacote": "21.5.1",
         "parse5-html-rewriting-stream": "8.0.0",
         "semver": "7.7.4",
         "yargs": "18.0.0",
@@ -3350,14 +3350,14 @@
       "license": "MIT"
     },
     "node_modules/@schematics/angular": {
-      "version": "21.2.15",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-21.2.15.tgz",
-      "integrity": "sha512-xdTirIUUegMXtyEDsYabCRcAnlVatVYb6S8v77fgK2eqUhGalI2e/3+L51N3XF1+6K2vEhyDpmmhFZLsdhLYbw==",
+      "version": "21.2.16",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-21.2.16.tgz",
+      "integrity": "sha512-ctvsRartACu77VAM416VlNV3mag7FhU08I/734f4+sS/UZmnhuTM5a4tTTWEI1U7iPeJoBtjreh6LgeP+QZLbQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "21.2.15",
-        "@angular-devkit/schematics": "21.2.15",
+        "@angular-devkit/core": "21.2.16",
+        "@angular-devkit/schematics": "21.2.16",
         "jsonc-parser": "3.3.1"
       },
       "engines": {
@@ -4642,13 +4642,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/err-code": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
-      "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/es-define-property": {
       "version": "1.0.1",
@@ -6739,16 +6732,6 @@
         "node": ">=20"
       }
     },
-    "node_modules/node-gyp/node_modules/undici": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.17"
-      }
-    },
     "node_modules/node-gyp/node_modules/which": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
@@ -7063,12 +7046,13 @@
       }
     },
     "node_modules/pacote": {
-      "version": "21.3.1",
-      "resolved": "https://registry.npmjs.org/pacote/-/pacote-21.3.1.tgz",
-      "integrity": "sha512-O0EDXi85LF4AzdjG74GUwEArhdvawi/YOHcsW6IijKNj7wm8IvEWNF5GnfuxNpQ/ZpO3L37+v8hqdVh8GgWYhg==",
+      "version": "21.5.1",
+      "resolved": "https://registry.npmjs.org/pacote/-/pacote-21.5.1.tgz",
+      "integrity": "sha512-KvcJ9iy3crysCsgqc4+PknH/w6jkrp8JN36mpZBPwNaDRwTfMZD37YzRazNstiZUOhuF5pno9f78n9mEJBavwg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
+        "@gar/promise-retry": "^1.0.0",
         "@npmcli/git": "^7.0.0",
         "@npmcli/installed-package-contents": "^4.0.0",
         "@npmcli/package-json": "^7.0.0",
@@ -7082,7 +7066,6 @@
         "npm-pick-manifest": "^11.0.1",
         "npm-registry-fetch": "^19.0.0",
         "proc-log": "^6.0.0",
-        "promise-retry": "^2.0.1",
         "sigstore": "^4.0.0",
         "ssri": "^13.0.0",
         "tar": "^7.4.3"
@@ -7355,20 +7338,6 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/promise-retry": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
-      "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "err-code": "^2.0.2",
-        "retry": "^0.12.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -7483,16 +7452,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/retry": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
     "node_modules/rfdc": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
@@ -7553,7 +7512,6 @@
       "version": "7.8.2",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
@@ -8156,9 +8114,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.24.4",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.4.tgz",
-      "integrity": "sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -15,7 +15,8 @@
     "esbuild": "0.28.1",
     "vite": "8.0.16",
     "@babel/core": "7.29.7",
-    "undici": "7.28.0"
+    "undici": "7.28.0",
+    "piscina": "5.2.0"
   },
   "dependencies": {
     "@angular/common": "21.2.17",

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -14,7 +14,8 @@
     "express-rate-limit": "8.5.1",
     "esbuild": "0.28.1",
     "vite": "8.0.16",
-    "@babel/core": "7.29.7"
+    "@babel/core": "7.29.7",
+    "undici": "7.28.0"
   },
   "dependencies": {
     "@angular/common": "21.2.17",
@@ -24,8 +25,8 @@
     "@angular/platform-browser-dynamic": "21.2.17"
   },
   "devDependencies": {
-    "@angular/build": "21.2.15",
-    "@angular/cli": "21.2.15",
+    "@angular/build": "21.2.16",
+    "@angular/cli": "21.2.16",
     "@angular/compiler-cli": "21.2.17",
     "@oncehub/ng-strictify": "2.0.10",
     "@types/node": "^25.5.0",


### PR DESCRIPTION
https://scheduleonce.atlassian.net/browse/ONCEHUB-122773
https://scheduleonce.atlassian.net/browse/ONCEHUB-122927
This pull request updates several dependencies in the `test-app` project, focusing primarily on Angular and related tooling, as well as some supporting libraries. The updates improve compatibility and may include important bug fixes and performance improvements.

Dependency updates (Angular & Tooling):

* Upgraded `@angular/build`, `@angular/cli`, and related Angular DevKit packages from version `21.2.15` to `21.2.16` in both `package.json` and `package-lock.json`. This also includes updates to `@schematics/angular` and `@angular/ssr`. [[1]](diffhunk://#diff-d882a6da5405468b3c5566a97ab3d19fb1d7e6c4d088fb0f027b4f2244cd4767L18-R19) [[2]](diffhunk://#diff-d882a6da5405468b3c5566a97ab3d19fb1d7e6c4d088fb0f027b4f2244cd4767L253-R259) [[3]](diffhunk://#diff-d882a6da5405468b3c5566a97ab3d19fb1d7e6c4d088fb0f027b4f2244cd4767L272-R274) [[4]](diffhunk://#diff-d882a6da5405468b3c5566a97ab3d19fb1d7e6c4d088fb0f027b4f2244cd4767L300-R306) [[5]](diffhunk://#diff-d882a6da5405468b3c5566a97ab3d19fb1d7e6c4d088fb0f027b4f2244cd4767L319-R326) [[6]](diffhunk://#diff-d882a6da5405468b3c5566a97ab3d19fb1d7e6c4d088fb0f027b4f2244cd4767L369-R369) [[7]](diffhunk://#diff-d882a6da5405468b3c5566a97ab3d19fb1d7e6c4d088fb0f027b4f2244cd4767L419-R438) [[8]](diffhunk://#diff-d882a6da5405468b3c5566a97ab3d19fb1d7e6c4d088fb0f027b4f2244cd4767L3353-R3360) [[9]](diffhunk://#diff-b03f4acb30e04ceb12a40763ef649759b3f632df2357bcec14fab6dd29ebbfb4L27-R30)

Supporting library updates:

* Updated `piscina` from `5.1.4` to `5.2.0` and `undici` from `7.24.4` to `7.28.0` in both `package.json` and `package-lock.json`. [[1]](diffhunk://#diff-d882a6da5405468b3c5566a97ab3d19fb1d7e6c4d088fb0f027b4f2244cd4767L7253-R7238) [[2]](diffhunk://#diff-d882a6da5405468b3c5566a97ab3d19fb1d7e6c4d088fb0f027b4f2244cd4767L8159-R8119) [[3]](diffhunk://#diff-b03f4acb30e04ceb12a40763ef649759b3f632df2357bcec14fab6dd29ebbfb4L17-R19)
* Updated `pacote` from `21.3.1` to `21.5.1`, replacing the `promise-retry` dependency with `@gar/promise-retry`. [[1]](diffhunk://#diff-d882a6da5405468b3c5566a97ab3d19fb1d7e6c4d088fb0f027b4f2244cd4767L419-R438) [[2]](diffhunk://#diff-d882a6da5405468b3c5566a97ab3d19fb1d7e6c4d088fb0f027b4f2244cd4767L7066-R7055) [[3]](diffhunk://#diff-d882a6da5405468b3c5566a97ab3d19fb1d7e6c4d088fb0f027b4f2244cd4767L7085)

Dependency cleanup:

* Removed unused or deprecated packages: `err-code`, `promise-retry`, and `retry` from `package-lock.json`. [[1]](diffhunk://#diff-d882a6da5405468b3c5566a97ab3d19fb1d7e6c4d088fb0f027b4f2244cd4767L4646-L4652) [[2]](diffhunk://#diff-d882a6da5405468b3c5566a97ab3d19fb1d7e6c4d088fb0f027b4f2244cd4767L7358-L7371) [[3]](diffhunk://#diff-d882a6da5405468b3c5566a97ab3d19fb1d7e6c4d088fb0f027b4f2244cd4767L7486-L7495)
* Removed `node-gyp/node_modules/undici` subdependency, likely as a result of dependency tree restructuring.

These changes help keep the project up-to-date with the latest stable releases and maintain a clean, efficient dependency tree.